### PR TITLE
Fix splitListItem when used with simpler list schema

### DIFF
--- a/src/schema-list.js
+++ b/src/schema-list.js
@@ -116,7 +116,7 @@ function splitListItem(nodeType) {
         $from.depth < 2 || !$from.sameParent($to)) return false
     let grandParent = $from.node(-1)
     if (grandParent.type != nodeType) return false
-    let nextType = $to.pos == $from.end() ? grandParent.defaultContentType($from.indexAfter(-1)) : null
+    let nextType = $to.pos == $from.end() ? grandParent.defaultContentType(0) : null
     let tr = state.tr.delete($from.pos, $to.pos)
     let types = nextType && [null, {type: nextType}]
     if (!canSplit(tr.doc, $from.pos, 2, types)) return false


### PR DESCRIPTION
`splitListItem` currently doesn't get applied (the `canSplit` condition ends up being false) when using a simpler list schema in which `list_item` content is defined as `"paragraph (ordered_list|bullet_list)?"`. This causes a bug when trying to split a list by pressing Enter with the caret at the end of a list item.

This PR re-applies a previously submitted and accepted fix https://github.com/ProseMirror/prosemirror/pull/450.

PS: If you have any ideas on how to add tests for this to avoid further regressions, I'd be happy to help add some. The problem I'm hitting trying to add tests (besides https://github.com/ProseMirror/prosemirror/issues/526) is that they depend on a default helper schema from `prosemirror-model`, and I can't see any easy way to derive a slightly modified schema to run tests against.