### PR TITLE
Fix a crash when lifting nested list

### DIFF
--- a/src/schema-list.ts
+++ b/src/schema-list.ts
@@ -179,7 +179,9 @@ function liftToOuterList(state: EditorState, dispatch: (tr: Transaction) => void
                                   new Slice(Fragment.from(itemType.create(null, range.parent.copy())), 1, 0), 1, true))
     range = new NodeRange(tr.doc.resolve(range.$from.pos), tr.doc.resolve(endOfList), range.depth)
   }
-  dispatch(tr.lift(range, liftTarget(range)!).scrollIntoView())
+  const target = liftTarget(range)
+  if (target == null) return false
+  dispatch(tr.lift(range, target).scrollIntoView())
   return true
 }
 


### PR DESCRIPTION
Close https://github.com/ProseMirror/prosemirror/issues/1299

In the case above, `liftTarget` will return `null`, which shouldn't be passed to `tr.lift` because `tr.lift` only accept number. 

Before the JS=>TS update, `liftTarge` here used to return `undefined`. `undefined` and `null` have different behavior when passed to `tr.lift`. That's why we see this bug after the TS version. 

```
> for (let d = 3; d > undefined; d--) { console.log(d) }
undefined
> for (let d = 3; d > null; d--) { console.log(d) }
3
2
1
undefined
>
```

I'm not sure if my fix is the perfect solution. In particular, from a user view, I still hope `Mod-[` can lift the nested item. But at least this patch fixes the crash. 
 
