### PR TITLE
Add splitListItemKeepMarks command

### DIFF
--- a/src/schema-list.ts
+++ b/src/schema-list.ts
@@ -155,6 +155,18 @@ export function splitListItem(itemType: NodeType): Command {
   }
 }
 
+/// Acts like [`splitListItem`](#schema-list.splitListItem), but without
+/// resetting the set of active marks at the cursor.
+export function splitListItemKeepMarks(itemType: NodeType) {
+  return function(state: EditorState, dispatch?: (tr: Transaction) => void) {
+    return splitListItem(itemType)(state, dispatch && (tr => {
+      let marks = state.storedMarks || (state.selection.$to.parentOffset && state.selection.$from.marks())
+      if (marks) tr.ensureMarks(marks)
+      dispatch(tr)
+    }))
+  }
+}
+
 /// Create a command to lift the list item around the selection up into
 /// a wrapping list.
 export function liftListItem(itemType: NodeType): Command {

--- a/src/schema-list.ts
+++ b/src/schema-list.ts
@@ -159,7 +159,9 @@ export function splitListItem(itemType: NodeType): Command {
 /// resetting the set of active marks at the cursor.
 export function splitListItemKeepMarks(itemType: NodeType) {
   return function(state: EditorState, dispatch?: (tr: Transaction) => void) {
-    return splitListItem(itemType)(state, dispatch && (tr => {
+    const split = splitListItem(itemType)
+    
+    return split(state, dispatch && (tr => {
       let marks = state.storedMarks || (state.selection.$to.parentOffset && state.selection.$from.marks())
       if (marks) tr.ensureMarks(marks)
       dispatch(tr)

--- a/test/test-commands.ts
+++ b/test/test-commands.ts
@@ -1,7 +1,7 @@
 import {EditorState, Selection, TextSelection, NodeSelection, Command} from "prosemirror-state"
-import {schema, eq, doc, blockquote, p, li, ol, ul} from "prosemirror-test-builder"
+import {schema, eq, doc, blockquote, p, li, ol, ul, strong} from "prosemirror-test-builder"
 import ist from "ist"
-import {wrapInList, splitListItem, liftListItem, sinkListItem} from "prosemirror-schema-list"
+import {wrapInList, splitListItem, liftListItem, sinkListItem, splitListItemKeepMarks} from "prosemirror-schema-list"
 import {Node} from "prosemirror-model"
 
 function selFor(doc: Node) {
@@ -83,6 +83,14 @@ describe("splitListItem", () => {
   it("correctly lifts an entirely empty sublist", () =>
      apply(doc(ul(li(p("one"), ul(li(p("<a>"))), p("two")))), split,
            doc(ul(li(p("one")), li(p("<a>")), li(p("two"))))))
+})
+
+describe("splitListItemKeepMarks", () => {
+   let splitWithMarks = splitListItemKeepMarks(schema.nodes.list_item)
+
+   it("preserves marks after splitting", () => 
+     apply(doc(ul(li(p(strong("foo<a>bar"))))), splitWithMarks, 
+           doc(ul(li(p(strong("foo"))), li(p(strong("bar")))))))
 })
 
 describe("liftListItem", () => {


### PR DESCRIPTION
This PR adds `splitListItemKeepMarks` command which replicates a behavior of [`splitBlockKeepMarks `](https://github.com/ProseMirror/prosemirror-commands/blob/master/src/commands.ts#L331) command for lists.

**Why?**

I was working on the requirements to preserve marks on the new line. I found that `splitBlockKeepMarks` command to be very useful for it, but could not find similar command for lists.

I think this is an important addition to this package, so it is consistent with the functionality provided by [prosemirror-commands](https://github.com/ProseMirror/prosemirror-commands).