### PR TITLE
Allow to pass optional attributes to splitListItem

### DIFF
--- a/src/schema-list.ts
+++ b/src/schema-list.ts
@@ -148,7 +148,7 @@ export function splitListItem(itemType: NodeType, attrs?: Attrs): Command {
     }
     let nextType = $to.pos == $from.end() ? grandParent.contentMatchAt(0).defaultType : null
     let tr = state.tr.delete($from.pos, $to.pos)
-    let types = nextType ? [{type: itemType, attrs}, {type: nextType}] : undefined
+    let types = nextType ? [attrs ? {type: itemType, attrs} : null, {type: nextType}] : undefined
     if (!canSplit(tr.doc, $from.pos, 2, types)) return false
     if (dispatch) dispatch(tr.split($from.pos, 2, types).scrollIntoView())
     return true

--- a/src/schema-list.ts
+++ b/src/schema-list.ts
@@ -111,7 +111,7 @@ function doWrapInList(tr: Transaction, range: NodeRange, wrappers: {type: NodeTy
 
 /// Build a command that splits a non-empty textblock at the top level
 /// of a list item by also splitting that list item.
-export function splitListItem(itemType: NodeType): Command {
+export function splitListItem(itemType: NodeType, attrs?: Attrs): Command {
   return function(state: EditorState, dispatch?: (tr: Transaction) => void) {
     let {$from, $to, node} = state.selection as NodeSelection
     if ((node && node.isBlock) || $from.depth < 2 || !$from.sameParent($to)) return false
@@ -148,7 +148,7 @@ export function splitListItem(itemType: NodeType): Command {
     }
     let nextType = $to.pos == $from.end() ? grandParent.contentMatchAt(0).defaultType : null
     let tr = state.tr.delete($from.pos, $to.pos)
-    let types = nextType ? [null, {type: nextType}] : undefined
+    let types = nextType ? [{type: itemType, attrs}, {type: nextType}] : undefined
     if (!canSplit(tr.doc, $from.pos, 2, types)) return false
     if (dispatch) dispatch(tr.split($from.pos, 2, types).scrollIntoView())
     return true


### PR DESCRIPTION
Hi,

When splitting a list item to create a new one, we may want the new item to have specific attributes. My use case is splitting items for a task list: if you split a checked item, you may want the new item to be unchecked. But as a default, the splitted node is copied with the same attribute, here `checked: true`.

**Problem:** somehow with the proposed code, `canSplitItem` is false. Yet if I uncomment this check, the splitting works well. I haven't yet figured the change needed in `canSplitItem`.

I haven't fully investigated but I suspect that in "prosemirror-transform/src/structure.ts" this check doesn't pass if I specify some attributes:

```
    if (after != node) rest = rest.replaceChild(0, after.type.create(after.attrs))
    if (!node.canReplace(index + 1, node.childCount) || !after.type.validContent(rest))
      return false
```

